### PR TITLE
Watch project not output dir

### DIFF
--- a/tests/esimport.test.js
+++ b/tests/esimport.test.js
@@ -60,6 +60,28 @@ describe('path2Import', () => {
   })
 })
 
+describe('isParentDir', () => {
+  test('is parent dir', () => {
+    assert.strictEqual(
+      esimport.isParentDir(
+        path.join(process.cwd(), 'tests/fixtures/fellowship'),
+        path.join(process.cwd(), 'tests/fixtures/fellowship/src'),
+      ),
+      true,
+    )
+  })
+
+  test('is not parent dir', () => {
+    assert.strictEqual(
+      esimport.isParentDir(
+        path.join(process.cwd(), 'tests/fixtures/fellowship/src'),
+        path.join(process.cwd(), 'tests/fixtures/fellowship'),
+      ),
+      false,
+    )
+  })
+})
+
 describe('resolveImport', () => {
   test('string', () => {
     assert.strictEqual(esimport.resolveImport('foo'), 'foo')


### PR DESCRIPTION
Make sure we watch the correct path and explicitly
exclude all subpaths of the output directory.

Thanks @SebastianKapunkt, good find!