### PR TITLE
Treeshake the import map to drop unused entry points

### DIFF
--- a/esimport.mjs
+++ b/esimport.mjs
@@ -244,25 +244,11 @@ export function treeShake(metafile, entryPointSourceMap, projectRoot) {
     }
   }
 
-  const queue = []
-
-  function mark(name) {
+  function* reachable(name) {
     if (name === undefined || reachableOutputs.has(name)) return
     reachableOutputs.add(name)
-    if (metafile.outputs[`${name}.map`] !== undefined) {
-      reachableOutputs.add(`${name}.map`)
-    }
-    queue.push(name)
-  }
-
-  for (const [source, name] of Object.entries(entryPointToOutput)) {
-    if (source.split(path.sep)[0] !== 'node_modules') {
-      mark(name)
-    }
-  }
-
-  while (queue.length > 0) {
-    const output = metafile.outputs[queue.shift()]
+    yield name
+    const output = metafile.outputs[name]
 
     if (output.entryPoint !== undefined) {
       for (const key of reverseEntryPointMap[
@@ -275,13 +261,23 @@ export function treeShake(metafile, entryPointSourceMap, projectRoot) {
     for (const { path: entryPoint } of output.imports) {
       const source = entryPointSourceMap[entryPoint]
       if (source !== undefined && entryPointToOutput[source] !== undefined) {
-        mark(entryPointToOutput[source])
+        yield* reachable(entryPointToOutput[source])
       } else if (metafile.outputs[entryPoint] !== undefined) {
-        mark(entryPoint)
+        yield* reachable(entryPoint)
       }
     }
 
-    mark(output.cssBundle)
+    yield* reachable(output.cssBundle)
+  }
+
+  for (const [source, name] of Object.entries(entryPointToOutput)) {
+    if (source.split(path.sep)[0] !== 'node_modules') {
+      for (const output of reachable(name)) {
+        if (metafile.outputs[`${output}.map`] !== undefined) {
+          reachableOutputs.add(`${output}.map`)
+        }
+      }
+    }
   }
 
   return { reachableKeys, reachableOutputs }

--- a/esimport.mjs
+++ b/esimport.mjs
@@ -221,6 +221,73 @@ export async function bundleExports(cwd, projectRoot) {
 }
 
 /**
+ * Determine the reachable entry points and output files from the build metafile.
+ *
+ * Walks the reachability graph from the project's own (1st-party) entry points. Only
+ * dependency entry points that are reachable from 1st-party code are kept in the
+ * import map; all other generated files are dropped.
+ *
+ * @param metafile {esbuild.Metafile} - The esbuild build metafile.
+ * @param entryPointSourceMap {Object.<string,string>} - A map of entry points to their file paths.
+ * @param projectRoot {string} - The root directory of the project.
+ * @return {{reachableKeys: Set<string>, reachableOutputs: Set<string>}} - The reachable import-map keys and output file paths to keep.
+ */
+export function treeShake(metafile, entryPointSourceMap, projectRoot) {
+  const reachableKeys = new Set()
+  const reachableOutputs = new Set()
+  const reverseEntryPointMap = invertObject(entryPointSourceMap)
+  const entryPointToOutput = {}
+
+  for (const [name, output] of Object.entries(metafile.outputs)) {
+    if (output.entryPoint !== undefined) {
+      entryPointToOutput[path.relative(projectRoot, output.entryPoint)] = name
+    }
+  }
+
+  const queue = []
+
+  function mark(name) {
+    if (name === undefined || reachableOutputs.has(name)) return
+    reachableOutputs.add(name)
+    if (metafile.outputs[`${name}.map`] !== undefined) {
+      reachableOutputs.add(`${name}.map`)
+    }
+    queue.push(name)
+  }
+
+  for (const [source, name] of Object.entries(entryPointToOutput)) {
+    if (source.split(path.sep)[0] !== 'node_modules') {
+      mark(name)
+    }
+  }
+
+  while (queue.length > 0) {
+    const output = metafile.outputs[queue.shift()]
+
+    if (output.entryPoint !== undefined) {
+      for (const key of reverseEntryPointMap[
+        path.relative(projectRoot, output.entryPoint)
+      ]) {
+        reachableKeys.add(key)
+      }
+    }
+
+    for (const { path: entryPoint } of output.imports) {
+      const source = entryPointSourceMap[entryPoint]
+      if (source !== undefined && entryPointToOutput[source] !== undefined) {
+        mark(entryPointToOutput[source])
+      } else if (metafile.outputs[entryPoint] !== undefined) {
+        mark(entryPoint)
+      }
+    }
+
+    mark(output.cssBundle)
+  }
+
+  return { reachableKeys, reachableOutputs }
+}
+
+/**
  * Build the project using esbuild.
  *
  * @param projectRoot {string} - The root directory of the project.
@@ -237,6 +304,10 @@ async function build(projectRoot, outputDir, context, entryPointSourceMap, optio
   }
   console.info(`${Object.keys(result.metafile.inputs).length} ES modules processed.`)
 
+  const reachable =
+    options.treeshake === false
+      ? undefined
+      : treeShake(result.metafile, entryPointSourceMap, projectRoot)
   const reverseEntryPointMap = invertObject(entryPointSourceMap)
 
   let entryPointOutputMap = {}
@@ -245,7 +316,17 @@ async function build(projectRoot, outputDir, context, entryPointSourceMap, optio
       for (const e of reverseEntryPointMap[
         path.relative(projectRoot, output.entryPoint)
       ]) {
-        entryPointOutputMap[e] = `./${path.relative(outputDir, name)}`
+        if (reachable === undefined || reachable.reachableKeys.has(e)) {
+          entryPointOutputMap[e] = `./${path.relative(outputDir, name)}`
+        }
+      }
+    }
+  }
+
+  if (reachable !== undefined) {
+    for (const name of Object.keys(result.metafile.outputs)) {
+      if (!reachable.reachableOutputs.has(name)) {
+        await fs.rm(name, { force: true })
       }
     }
   }
@@ -568,6 +649,7 @@ export async function main(argv) {
       '-p, --path-prefix <path>',
       'Prefix all import paths with the given path. Useful when serving behind a reverse proxy.',
     )
+    .option('--no-treeshake', 'Bundle all entry points into the import map.')
     .argument(
       '<package-dir>',
       'Path to package that will transformed. The directory must contain a valid package.json file.',

--- a/esimport.mjs
+++ b/esimport.mjs
@@ -221,11 +221,92 @@ export async function bundleExports(cwd, projectRoot) {
 }
 
 /**
- * Determine the reachable entry points and output files from the build metafile.
- *
- * Walks the reachability graph from the project's own (1st-party) entry points. Only
- * dependency entry points that are reachable from 1st-party code are kept in the
- * import map; all other generated files are dropped.
+ * The reachability graph walker over the build metafile.
+ */
+class TreeShaker {
+  #metafile
+  #entryPointSourceMap
+  #projectRoot
+  #reachableKeys = new Set()
+  #reachableOutputs = new Set()
+  #reverseEntryPointMap
+  #entryPointToOutput = {}
+
+  /**
+   * Walker over the metafile's reachability graph from the project's own entry points.
+   *
+   * @param metafile {esbuild.Metafile} - The esbuild build metafile.
+   * @param entryPointSourceMap {Object.<string,string>} - A map of entry points to their file paths.
+   * @param projectRoot {string} - The root directory of the project.
+   */
+  constructor(metafile, entryPointSourceMap, projectRoot) {
+    this.#metafile = metafile
+    this.#entryPointSourceMap = entryPointSourceMap
+    this.#projectRoot = projectRoot
+    this.#reverseEntryPointMap = invertObject(entryPointSourceMap)
+    for (const [name, output] of Object.entries(metafile.outputs)) {
+      if (output.entryPoint !== undefined) {
+        this.#entryPointToOutput[path.relative(projectRoot, output.entryPoint)] = name
+      }
+    }
+  }
+
+  /**
+   * Yield the output and every output it reaches.
+   *
+   * @param name {string|undefined} - The name of the output to walk.
+   * @yields {string} - The names of the reachable outputs.
+   */
+  *#walk(name) {
+    if (name === undefined || this.#reachableOutputs.has(name)) return
+    this.#reachableOutputs.add(name)
+    yield name
+    const output = this.#metafile.outputs[name]
+
+    if (output.entryPoint !== undefined) {
+      for (const key of this.#reverseEntryPointMap[
+        path.relative(this.#projectRoot, output.entryPoint)
+      ]) {
+        this.#reachableKeys.add(key)
+      }
+    }
+
+    for (const { path: entryPoint } of output.imports) {
+      const source = this.#entryPointSourceMap[entryPoint]
+      if (source !== undefined && this.#entryPointToOutput[source] !== undefined) {
+        yield* this.#walk(this.#entryPointToOutput[source])
+      } else if (this.#metafile.outputs[entryPoint] !== undefined) {
+        yield* this.#walk(entryPoint)
+      }
+    }
+
+    yield* this.#walk(output.cssBundle)
+  }
+
+  /**
+   * Return the import-map keys and outputs reachable from the project's entry points.
+   *
+   * @return {{reachableKeys: Set<string>, reachableOutputs: Set<string>}} - The reachable import-map keys and output file paths to keep.
+   */
+  reachable() {
+    for (const [source, name] of Object.entries(this.#entryPointToOutput)) {
+      if (source.split(path.sep)[0] !== 'node_modules') {
+        for (const output of this.#walk(name)) {
+          if (this.#metafile.outputs[`${output}.map`] !== undefined) {
+            this.#reachableOutputs.add(`${output}.map`)
+          }
+        }
+      }
+    }
+    return {
+      reachableKeys: this.#reachableKeys,
+      reachableOutputs: this.#reachableOutputs,
+    }
+  }
+}
+
+/**
+ * Shake the project's import tree down to its reachable outputs.
  *
  * @param metafile {esbuild.Metafile} - The esbuild build metafile.
  * @param entryPointSourceMap {Object.<string,string>} - A map of entry points to their file paths.
@@ -233,54 +314,7 @@ export async function bundleExports(cwd, projectRoot) {
  * @return {{reachableKeys: Set<string>, reachableOutputs: Set<string>}} - The reachable import-map keys and output file paths to keep.
  */
 export function treeShake(metafile, entryPointSourceMap, projectRoot) {
-  const reachableKeys = new Set()
-  const reachableOutputs = new Set()
-  const reverseEntryPointMap = invertObject(entryPointSourceMap)
-  const entryPointToOutput = {}
-
-  for (const [name, output] of Object.entries(metafile.outputs)) {
-    if (output.entryPoint !== undefined) {
-      entryPointToOutput[path.relative(projectRoot, output.entryPoint)] = name
-    }
-  }
-
-  function* reachable(name) {
-    if (name === undefined || reachableOutputs.has(name)) return
-    reachableOutputs.add(name)
-    yield name
-    const output = metafile.outputs[name]
-
-    if (output.entryPoint !== undefined) {
-      for (const key of reverseEntryPointMap[
-        path.relative(projectRoot, output.entryPoint)
-      ]) {
-        reachableKeys.add(key)
-      }
-    }
-
-    for (const { path: entryPoint } of output.imports) {
-      const source = entryPointSourceMap[entryPoint]
-      if (source !== undefined && entryPointToOutput[source] !== undefined) {
-        yield* reachable(entryPointToOutput[source])
-      } else if (metafile.outputs[entryPoint] !== undefined) {
-        yield* reachable(entryPoint)
-      }
-    }
-
-    yield* reachable(output.cssBundle)
-  }
-
-  for (const [source, name] of Object.entries(entryPointToOutput)) {
-    if (source.split(path.sep)[0] !== 'node_modules') {
-      for (const output of reachable(name)) {
-        if (metafile.outputs[`${output}.map`] !== undefined) {
-          reachableOutputs.add(`${output}.map`)
-        }
-      }
-    }
-  }
-
-  return { reachableKeys, reachableOutputs }
+  return new TreeShaker(metafile, entryPointSourceMap, projectRoot).reachable()
 }
 
 /**

--- a/tests/esimport.test.js
+++ b/tests/esimport.test.js
@@ -9,7 +9,7 @@ import { run, UnenvResolvePlugin } from 'esimport'
 
 describe('integrityHashes', () => {
   test('default algorithms', () => {
-    assert.deepStrictEqual(
+    assert.deepEqual(
       [...esimport.integrityHashes('foo')],
       [
         'sha256-LCa0a2j/xo/5m0U8HTBBNBNCLXBkg7+g+YpeiGJm564=',
@@ -20,7 +20,7 @@ describe('integrityHashes', () => {
   })
 
   test('custom algorithms', () => {
-    assert.deepStrictEqual(
+    assert.deepEqual(
       [...esimport.integrityHashes('foo', ['sha512'])],
       [
         'sha512-9/u6bgY2+JDlb7vzKD5STG+jIErimDgtYkdB0NxmODJuKCxBvl5CVNiCB3LFUYosWowMf37aGVlKfrU5RT4e1w==',
@@ -135,13 +135,13 @@ describe('resolveImport', () => {
 
 describe('resolveEntryPoints', () => {
   test('string', () => {
-    assert.deepStrictEqual(esimport.resolveEntryPoints('fellowship', './ring.js'), {
+    assert.deepEqual(esimport.resolveEntryPoints('fellowship', './ring.js'), {
       fellowship: './ring.js',
     })
   })
 
   test('array', () => {
-    assert.deepStrictEqual(
+    assert.deepEqual(
       esimport.resolveEntryPoints('fellowship', ['./ring.js', './gandalf.js']),
       {
         'fellowship/ring.js': './ring.js',
@@ -151,7 +151,7 @@ describe('resolveEntryPoints', () => {
   })
 
   test('object', () => {
-    assert.deepStrictEqual(
+    assert.deepEqual(
       esimport.resolveEntryPoints('fellowship', {
         ring: './ring.js',
         gandalf: './gandalf.js',
@@ -164,7 +164,7 @@ describe('resolveEntryPoints', () => {
   })
 
   test('single entrypoint object', () => {
-    assert.deepStrictEqual(
+    assert.deepEqual(
       esimport.resolveEntryPoints('fellowship', {
         default: './ring.mjs',
         node: './ring.cjs',
@@ -185,7 +185,7 @@ describe('resolveEntryPoints', () => {
 
 describe('expandSubpathPattern', () => {
   test('no wildcard', async () => {
-    assert.deepStrictEqual(
+    assert.deepEqual(
       await esimport.expandSubpathPattern(
         './src/index.js',
         'tests/fixtures/fellowship',
@@ -195,7 +195,7 @@ describe('expandSubpathPattern', () => {
   })
 
   test('wildcard w/ subpath', async () => {
-    assert.deepStrictEqual(
+    assert.deepEqual(
       new Set(
         await esimport.expandSubpathPattern('./src/*.js', 'tests/fixtures/fellowship'),
       ),
@@ -209,7 +209,7 @@ describe('expandSubpathPattern', () => {
   })
 
   test('wildcard w/o subpath', async () => {
-    assert.deepStrictEqual(
+    assert.deepEqual(
       await esimport.expandSubpathPattern(
         './src/hobbits/*.js',
         'tests/fixtures/fellowship',
@@ -219,7 +219,7 @@ describe('expandSubpathPattern', () => {
   })
 
   test('no match', async () => {
-    assert.deepStrictEqual(
+    assert.deepEqual(
       await esimport.expandSubpathPattern('./src/*.js', 'tests/fixtures/rings'),
       [],
     )
@@ -228,7 +228,7 @@ describe('expandSubpathPattern', () => {
 
 describe('expandEntryPoints', () => {
   test('string', async () => {
-    assert.deepStrictEqual(
+    assert.deepEqual(
       await esimport.expandEntryPoints(
         'fellowship',
         './src/index.js',
@@ -242,7 +242,7 @@ describe('expandEntryPoints', () => {
   })
 
   test('array', async () => {
-    assert.deepStrictEqual(
+    assert.deepEqual(
       await esimport.expandEntryPoints(
         'fellowship',
         ['./src/index.js', './src/hobbits/*.js'],
@@ -258,7 +258,7 @@ describe('expandEntryPoints', () => {
   })
 
   test('object', async () => {
-    assert.deepStrictEqual(
+    assert.deepEqual(
       await esimport.expandEntryPoints(
         'fellowship',
         {
@@ -277,7 +277,7 @@ describe('expandEntryPoints', () => {
   })
 
   test('exclude', async () => {
-    assert.deepStrictEqual(
+    assert.deepEqual(
       await esimport.expandEntryPoints(
         'fellowship',
         {
@@ -300,7 +300,7 @@ describe('expandEntryPoints', () => {
 
 describe('bundleExports', () => {
   test('exports', async () => {
-    assert.deepStrictEqual(
+    assert.deepEqual(
       await esimport.bundleExports(
         path.join(process.cwd(), 'tests/fixtures/fellowship'),
         path.join(process.cwd(), 'tests/fixtures'),
@@ -316,7 +316,7 @@ describe('bundleExports', () => {
 
 describe('invertObject', () => {
   test('invert object', () => {
-    assert.deepStrictEqual(
+    assert.deepEqual(
       esimport.invertObject({
         foo: 'bar',
         baz: 'qux',
@@ -408,8 +408,8 @@ describe('treeShake', () => {
       entryPointSourceMap,
       projectRoot,
     )
-    assert.ok(reachableKeys.has('app'))
-    assert.ok(reachableOutputs.has('/project/out/app.js'))
+    assert(reachableKeys.has('app'))
+    assert(reachableOutputs.has('/project/out/app.js'))
   })
 
   test('keeps transitively imported dep subpath and drops unreferenced dep', () => {
@@ -418,10 +418,10 @@ describe('treeShake', () => {
       entryPointSourceMap,
       projectRoot,
     )
-    assert.ok(reachableKeys.has('dep/sub'))
-    assert.ok(reachableOutputs.has('/project/out/dep-locale.js'))
-    assert.ok(!reachableKeys.has('dep'))
-    assert.ok(!reachableOutputs.has('/project/out/dep.js'))
+    assert(reachableKeys.has('dep/sub'))
+    assert(reachableOutputs.has('/project/out/dep-locale.js'))
+    assert(!reachableKeys.has('dep'))
+    assert(!reachableOutputs.has('/project/out/dep.js'))
   })
 
   test('keeps cssBundle output for a reachable output', () => {
@@ -430,7 +430,7 @@ describe('treeShake', () => {
       entryPointSourceMap,
       projectRoot,
     )
-    assert.ok(reachableOutputs.has('/project/out/styles.css'))
+    assert(reachableOutputs.has('/project/out/styles.css'))
   })
 
   test('keeps split-chunk outputs referenced via imports', () => {
@@ -439,7 +439,7 @@ describe('treeShake', () => {
       entryPointSourceMap,
       projectRoot,
     )
-    assert.ok(reachableOutputs.has('/project/out/chunk.js'))
+    assert(reachableOutputs.has('/project/out/chunk.js'))
   })
 
   test('keeps .map companion outputs for reachable outputs', () => {
@@ -454,15 +454,15 @@ describe('treeShake', () => {
       '/project/out/styles.css.map',
       '/project/out/chunk.js.map',
     ]) {
-      assert.ok(reachableOutputs.has(name))
+      assert(reachableOutputs.has(name))
     }
-    assert.ok(!reachableOutputs.has('/project/out/dep.js.map'))
+    assert(!reachableOutputs.has('/project/out/dep.js.map'))
   })
 })
 
 describe('compileEntryPoints', () => {
   test('compile entry points', async () => {
-    assert.deepStrictEqual(
+    assert.deepEqual(
       await esimport.compileEntryPoints(
         path.join(import.meta.dirname, 'fixtures/fellowship'),
       ),
@@ -484,7 +484,7 @@ describe('UnenvResolvePlugin', () => {
     const onResolve = mock.fn()
     const build = { onResolve }
     plugin.setup(build)
-    assert.deepStrictEqual(onResolve.mock.calls[0].arguments, [
+    assert.deepEqual(onResolve.mock.calls[0].arguments, [
       {
         filter:
           /^(node:)?(assert|assert\/strict|async_hooks|buffer|child_process|cluster|console|constants|crypto|dgram|diagnostics_channel|dns|dns\/promises|domain|events|fs|fs\/promises|http|http2|https|inspector|inspector\/promises|module|net|os|path|path\/posix|path\/win32|perf_hooks|process|punycode|querystring|readline|readline\/promises|repl|stream|stream\/consumers|stream\/promises|stream\/web|string_decoder|sys|timers|timers\/promises|tls|trace_events|tty|url|util|util\/types|v8|vm|wasi|worker_threads|zlib)$/,
@@ -494,18 +494,15 @@ describe('UnenvResolvePlugin', () => {
   })
 
   test('unenvCallback', async () => {
-    assert.deepStrictEqual(
-      await esimport.UnenvResolvePlugin.unenvCallback({ path: 'url' }),
-      {
-        external: false,
-        path: path.join(
-          import.meta.dirname,
-          `../node_modules/unenv/dist/runtime/node/url.mjs`,
-        ),
-      },
-    )
+    assert.deepEqual(await esimport.UnenvResolvePlugin.unenvCallback({ path: 'url' }), {
+      external: false,
+      path: path.join(
+        import.meta.dirname,
+        `../node_modules/unenv/dist/runtime/node/url.mjs`,
+      ),
+    })
 
-    assert.deepStrictEqual(
+    assert.deepEqual(
       await esimport.UnenvResolvePlugin.unenvCallback({ path: 'node:url' }),
       {
         external: false,
@@ -525,7 +522,7 @@ describe('run', () => {
       path.join(import.meta.dirname, 'fixtures/out'),
       { watch: false, verbose: true },
     )
-    assert.deepStrictEqual(result, {
+    assert.deepEqual(result, {
       imports: {
         fellowship: './src/index-5CNBNISI.js',
         'fellowship/hobbits/sam.js': './src/hobbits/sam-7ELSRYCS.js',
@@ -562,39 +559,39 @@ describe('run (treeshake)', () => {
         watch: false,
         verbose: false,
       })
-      assert.deepStrictEqual(Object.keys(result.imports).sort(), [
+      assert.deepEqual(Object.keys(result.imports).sort(), [
         'date-utils/locale',
         'treeshake-app',
       ])
-      assert.deepStrictEqual(
+      assert.deepEqual(
         Object.keys(result.integrity).sort(),
         Object.values(result.imports).sort(),
       )
       const files = await listFiles(outputDir)
-      assert.ok(files.includes('importmap.json'))
-      assert.ok(
+      assert(files.includes('importmap.json'))
+      assert(
         files.some((f) => /^src\/index-.*\.js$/.test(f)),
         'expected kept src/index-*.js',
       )
-      assert.ok(
+      assert(
         files.some((f) => /^src\/index-.*\.js\.map$/.test(f)),
         'expected kept src/index-*.js.map',
       )
-      assert.ok(
+      assert(
         files.some((f) => /^node_modules\/date-utils\/locale\/index-.*\.js$/.test(f)),
         'expected kept date-utils/locale output',
       )
-      assert.ok(
+      assert(
         files.some((f) =>
           /^node_modules\/date-utils\/locale\/index-.*\.js\.map$/.test(f),
         ),
         'expected kept date-utils/locale .map',
       )
-      assert.ok(
+      assert(
         !files.some((f) => /^node_modules\/date-utils\/index-.*/.test(f)),
         'unused date-utils output must be removed',
       )
-      assert.ok(
+      assert(
         !files.some((f) => /^node_modules\/date-utils\/fp\/index-.*/.test(f)),
         'unused date-utils/fp output must be removed',
       )
@@ -611,18 +608,18 @@ describe('run (treeshake)', () => {
         verbose: false,
         treeshake: false,
       })
-      assert.deepStrictEqual(Object.keys(result.imports).sort(), [
+      assert.deepEqual(Object.keys(result.imports).sort(), [
         'date-utils',
         'date-utils/fp',
         'date-utils/locale',
         'treeshake-app',
       ])
       const files = await listFiles(outputDir)
-      assert.ok(
+      assert(
         files.some((f) => /^node_modules\/date-utils\/index-.*\.js$/.test(f)),
         'date-utils output should exist without treeshake',
       )
-      assert.ok(
+      assert(
         files.some((f) => /^node_modules\/date-utils\/fp\/index-.*\.js$/.test(f)),
         'date-utils/fp output should exist without treeshake',
       )
@@ -634,7 +631,7 @@ describe('run (treeshake)', () => {
 
 describe('parsePort', () => {
   test('parsePort', () => {
-    assert.deepStrictEqual(esimport.parsePort('3000'), 3000)
+    assert.deepEqual(esimport.parsePort('3000'), 3000)
     assert.throws(
       () => esimport.parsePort('80'),
       /Port must be between 1024 and 49151./,

--- a/tests/esimport.test.js
+++ b/tests/esimport.test.js
@@ -1,6 +1,7 @@
 import assert from 'node:assert'
 import process from 'node:process'
 import path from 'node:path'
+import fs from 'node:fs/promises'
 import { describe, mock, test } from 'node:test'
 
 import * as esimport from 'esimport'
@@ -328,6 +329,137 @@ describe('invertObject', () => {
   })
 })
 
+describe('treeShake', () => {
+  const projectRoot = '/project'
+  const entryPointSourceMap = {
+    app: 'src/index.js',
+    dep: 'node_modules/dep/index.js',
+    'dep/sub': 'node_modules/dep/locale/index.js',
+  }
+
+  function makeMetafile() {
+    return {
+      outputs: {
+        '/project/out/app.js': {
+          entryPoint: path.join(projectRoot, 'src/index.js'),
+          imports: [
+            { path: 'dep/sub', kind: 'import-statement', external: false },
+            {
+              path: '/project/out/chunk.js',
+              kind: 'import-statement',
+              external: false,
+            },
+          ],
+          cssBundle: '/project/out/styles.css',
+          inputs: {},
+        },
+        '/project/out/app.js.map': {
+          entryPoint: undefined,
+          imports: [],
+          inputs: {},
+        },
+        '/project/out/dep.js': {
+          entryPoint: path.join(projectRoot, 'node_modules/dep/index.js'),
+          imports: [],
+          inputs: {},
+        },
+        '/project/out/dep.js.map': {
+          entryPoint: undefined,
+          imports: [],
+          inputs: {},
+        },
+        '/project/out/dep-locale.js': {
+          entryPoint: path.join(projectRoot, 'node_modules/dep/locale/index.js'),
+          imports: [],
+          inputs: {},
+        },
+        '/project/out/dep-locale.js.map': {
+          entryPoint: undefined,
+          imports: [],
+          inputs: {},
+        },
+        '/project/out/styles.css': {
+          entryPoint: undefined,
+          imports: [],
+          inputs: {},
+        },
+        '/project/out/styles.css.map': {
+          entryPoint: undefined,
+          imports: [],
+          inputs: {},
+        },
+        '/project/out/chunk.js': {
+          entryPoint: undefined,
+          imports: [],
+          inputs: {},
+        },
+        '/project/out/chunk.js.map': {
+          entryPoint: undefined,
+          imports: [],
+          inputs: {},
+        },
+      },
+    }
+  }
+
+  test('keeps 1st-party root entry point and its output', () => {
+    const { reachableKeys, reachableOutputs } = esimport.treeShake(
+      makeMetafile(),
+      entryPointSourceMap,
+      projectRoot,
+    )
+    assert.ok(reachableKeys.has('app'))
+    assert.ok(reachableOutputs.has('/project/out/app.js'))
+  })
+
+  test('keeps transitively imported dep subpath and drops unreferenced dep', () => {
+    const { reachableKeys, reachableOutputs } = esimport.treeShake(
+      makeMetafile(),
+      entryPointSourceMap,
+      projectRoot,
+    )
+    assert.ok(reachableKeys.has('dep/sub'))
+    assert.ok(reachableOutputs.has('/project/out/dep-locale.js'))
+    assert.ok(!reachableKeys.has('dep'))
+    assert.ok(!reachableOutputs.has('/project/out/dep.js'))
+  })
+
+  test('keeps cssBundle output for a reachable output', () => {
+    const { reachableOutputs } = esimport.treeShake(
+      makeMetafile(),
+      entryPointSourceMap,
+      projectRoot,
+    )
+    assert.ok(reachableOutputs.has('/project/out/styles.css'))
+  })
+
+  test('keeps split-chunk outputs referenced via imports', () => {
+    const { reachableOutputs } = esimport.treeShake(
+      makeMetafile(),
+      entryPointSourceMap,
+      projectRoot,
+    )
+    assert.ok(reachableOutputs.has('/project/out/chunk.js'))
+  })
+
+  test('keeps .map companion outputs for reachable outputs', () => {
+    const { reachableOutputs } = esimport.treeShake(
+      makeMetafile(),
+      entryPointSourceMap,
+      projectRoot,
+    )
+    for (const name of [
+      '/project/out/app.js.map',
+      '/project/out/dep-locale.js.map',
+      '/project/out/styles.css.map',
+      '/project/out/chunk.js.map',
+    ]) {
+      assert.ok(reachableOutputs.has(name))
+    }
+    assert.ok(!reachableOutputs.has('/project/out/dep.js.map'))
+  })
+})
+
 describe('compileEntryPoints', () => {
   test('compile entry points', async () => {
     assert.deepStrictEqual(
@@ -408,6 +540,95 @@ describe('run', () => {
           'sha256-75BZz/UpPligxcmAdJnH+TJd/CIyRSjLA54xBpnRakQ= sha384-7mjoGvP3jSYReNFlnO6afThCYcCfvesfEDNcFTyAy3SAv5nJRCkYQ3ptT7kn43AK sha512-7dyswrItDz1PnA44eyfyzvWT1BqBf3AVXfBay914dNi3dJUSTOa0LE2zyGT/b+lNNNPLAS/+P87BL24pMsZZAA==',
       },
     })
+  })
+})
+
+describe('run (treeshake)', () => {
+  const fixtureDir = path.join(import.meta.dirname, 'fixtures/treeshake')
+  const outputDir = path.join(import.meta.dirname, 'fixtures/treeshake/out')
+
+  async function listFiles(dir) {
+    const files = []
+    for (const entry of await fs.readdir(dir, { recursive: true })) {
+      if ((await fs.stat(path.join(dir, entry))).isFile()) files.push(entry)
+    }
+    return files.sort()
+  }
+
+  test('treeshakes unreachable dependency entry points by default', async () => {
+    await fs.rm(outputDir, { recursive: true, force: true })
+    try {
+      const result = await esimport.run(fixtureDir, outputDir, {
+        watch: false,
+        verbose: false,
+      })
+      assert.deepStrictEqual(Object.keys(result.imports).sort(), [
+        'date-utils/locale',
+        'treeshake-app',
+      ])
+      assert.deepStrictEqual(
+        Object.keys(result.integrity).sort(),
+        Object.values(result.imports).sort(),
+      )
+      const files = await listFiles(outputDir)
+      assert.ok(files.includes('importmap.json'))
+      assert.ok(
+        files.some((f) => /^src\/index-.*\.js$/.test(f)),
+        'expected kept src/index-*.js',
+      )
+      assert.ok(
+        files.some((f) => /^src\/index-.*\.js\.map$/.test(f)),
+        'expected kept src/index-*.js.map',
+      )
+      assert.ok(
+        files.some((f) => /^node_modules\/date-utils\/locale\/index-.*\.js$/.test(f)),
+        'expected kept date-utils/locale output',
+      )
+      assert.ok(
+        files.some((f) =>
+          /^node_modules\/date-utils\/locale\/index-.*\.js\.map$/.test(f),
+        ),
+        'expected kept date-utils/locale .map',
+      )
+      assert.ok(
+        !files.some((f) => /^node_modules\/date-utils\/index-.*/.test(f)),
+        'unused date-utils output must be removed',
+      )
+      assert.ok(
+        !files.some((f) => /^node_modules\/date-utils\/fp\/index-.*/.test(f)),
+        'unused date-utils/fp output must be removed',
+      )
+    } finally {
+      await fs.rm(outputDir, { recursive: true, force: true })
+    }
+  })
+
+  test('keeps all entry points when treeshake is disabled', async () => {
+    await fs.rm(outputDir, { recursive: true, force: true })
+    try {
+      const result = await esimport.run(fixtureDir, outputDir, {
+        watch: false,
+        verbose: false,
+        treeshake: false,
+      })
+      assert.deepStrictEqual(Object.keys(result.imports).sort(), [
+        'date-utils',
+        'date-utils/fp',
+        'date-utils/locale',
+        'treeshake-app',
+      ])
+      const files = await listFiles(outputDir)
+      assert.ok(
+        files.some((f) => /^node_modules\/date-utils\/index-.*\.js$/.test(f)),
+        'date-utils output should exist without treeshake',
+      )
+      assert.ok(
+        files.some((f) => /^node_modules\/date-utils\/fp\/index-.*\.js$/.test(f)),
+        'date-utils/fp output should exist without treeshake',
+      )
+    } finally {
+      await fs.rm(outputDir, { recursive: true, force: true })
+    }
   })
 })
 

--- a/tests/esimport.test.js
+++ b/tests/esimport.test.js
@@ -1,4 +1,4 @@
-import assert from 'node:assert'
+import assert from 'node:assert/strict'
 import process from 'node:process'
 import path from 'node:path'
 import fs from 'node:fs/promises'

--- a/tests/fixtures/treeshake/.gitignore
+++ b/tests/fixtures/treeshake/.gitignore
@@ -1,0 +1,4 @@
+# Re-include the dependency fixture, which is otherwise excluded by the
+# top-level node_modules/ rule.
+!node_modules/
+!node_modules/**

--- a/tests/fixtures/treeshake/node_modules/date-utils/fp/index.js
+++ b/tests/fixtures/treeshake/node_modules/date-utils/fp/index.js
@@ -1,0 +1,3 @@
+export function fp() {
+  return 'unused';
+}

--- a/tests/fixtures/treeshake/node_modules/date-utils/index.js
+++ b/tests/fixtures/treeshake/node_modules/date-utils/index.js
@@ -1,0 +1,1 @@
+export function add() {}

--- a/tests/fixtures/treeshake/node_modules/date-utils/locale/en-US/index.js
+++ b/tests/fixtures/treeshake/node_modules/date-utils/locale/en-US/index.js
@@ -1,0 +1,1 @@
+export const locale = 'en-US'

--- a/tests/fixtures/treeshake/node_modules/date-utils/locale/index.js
+++ b/tests/fixtures/treeshake/node_modules/date-utils/locale/index.js
@@ -1,0 +1,5 @@
+import { locale } from './en-US/index.js'
+
+export function format() {
+  return locale;
+}

--- a/tests/fixtures/treeshake/node_modules/date-utils/package.json
+++ b/tests/fixtures/treeshake/node_modules/date-utils/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "date-utils",
+  "version": "1.0.0",
+  "exports": {
+    ".": "./index.js",
+    "./locale": "./locale/index.js",
+    "./fp": "./fp/index.js"
+  }
+}

--- a/tests/fixtures/treeshake/package.json
+++ b/tests/fixtures/treeshake/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "treeshake-app",
+  "version": "1.0.0",
+  "description": "Test fixture for import map treeshaking.",
+  "exports": {
+    ".": "./src/index.js"
+  },
+  "dependencies": {
+    "date-utils": "1.0.0"
+  }
+}

--- a/tests/fixtures/treeshake/src/index.js
+++ b/tests/fixtures/treeshake/src/index.js
@@ -1,0 +1,3 @@
+import { format } from 'date-utils/locale'
+
+export const message = format


### PR DESCRIPTION
## Why

Packages can define a lot of entry points, adding bloat to the import map. A clear example is `date-fns`, which exposes 740+ subpaths; importing only `date-fns/locale` still pulled every entry point into the map, inflating every rendered page (up to 95% of the HTML size in the linked discussion).

Fixes: #110

## Approach

After esbuild bundles all entry points in a single pass, we now walk the build metafile's reachability graph starting from the project's own (1st-party) entry points and keep only the entry points reachable from that code in the import map. Unreachable generated files are removed from the output directory.

- **`treeShake(metafile, entryPointSourceMap, projectRoot)`** returns the reachable import-map keys and output file paths.
- The traversal is a `TreeShaker` class holding shared state, walking via a private generator method (`#walk`) using `yield`/`yield*` instead of an array queue.
- Kept outputs include reachable dependency subpaths (transitive), split-chunk outputs referenced through `imports[].path`, CSS bundles via `cssBundle`, and each output's `.map` sourcemap companion.
- **Always on by default**; a new `--no-treeshake` flag opts out and preserves the full map.
- All 1st-party entry points are kept unconditionally (they are the public API the browser loads); only unreachable *dependency* entry points are dropped.

## Notes for reviewers

- **Sourcemaps preserved**: each kept output's `.map` companion is retained; only unreachable outputs (and their maps) are deleted.
- **Split chunks**: real esbuild metafiles reference split-chunk outputs via `imports[].path` (not `outputs[].inputs`, which only ever holds source files), so the walk follows that path. `run()` does not currently enable splitting, but the logic is correct for it.
- **Windows**: first-party detection splits on `path.sep`, so it works on both POSIX and Windows.
- **Deletion safety**: the `fs.rm` cleanup only ever removes paths that esbuild itself emitted under the output directory (keys of `metafile.outputs`); it is non-recursive and never touches `importmap.json`.

## Tests

- 5 unit tests for `treeShake` (synthetic metafile): 1st-party root kept, transitive dependency subpath kept, unreferenced dependency dropped, cssBundle kept, split-chunk output kept, `.map` companions kept.
- 2 end-to-end `run` tests using a new `tests/fixtures/treeshake/` fixture (a project importing only `date-utils/locale` out of several exports): default treeshake keeps only `treeshake-app` + `date-utils/locale` and removes unused outputs; `treeshake: false` keeps all four entry points.
- Full suite: 43/43 passing.