### PR TITLE
Treeshake the import map to drop unused entry points

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,11 +39,18 @@ ESM is the future. _No bundling, no bullsh\*t._
 ## Usage
 
 ```bash
-# esimport <package-root> <output-dir> [--watch,--serve,--path-prefix,--verbose,--no-treeshake,--help]
+# esimport <package-root> <output-dir> [--watch,--serve,--path-prefix,--verbose,--treeshake,--help]
 npx esimport . ./public/static/  --serve
 ```
 
 That's it!
+
+### Treeshaking
+
+By default, esimport bundles every entry point into the import map. Pass
+`--treeshake` to drop [package entry points](https://nodejs.org/api/packages.html#package-entry-points)
+that are not reachable from the project's own entry points, keeping the
+outputs actually imported and removing the rest.
 
 ### Output
 

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ ESM is the future. _No bundling, no bullsh\*t._
 ## Usage
 
 ```bash
-# esimport <package-root> <output-dir> [--watch,--serve,--path-prefix,--verbose,--help]
+# esimport <package-root> <output-dir> [--watch,--serve,--path-prefix,--verbose,--no-treeshake,--help]
 npx esimport . ./public/static/  --serve
 ```
 

--- a/esimport.mjs
+++ b/esimport.mjs
@@ -312,10 +312,9 @@ async function build(projectRoot, outputDir, context, entryPointSourceMap, optio
   }
   console.info(`${Object.keys(result.metafile.inputs).length} ES modules processed.`)
 
-  const reachable =
-    options.treeshake === false
-      ? undefined
-      : treeShake(result.metafile, entryPointSourceMap, projectRoot)
+  const reachable = options.treeshake
+    ? treeShake(result.metafile, entryPointSourceMap, projectRoot)
+    : undefined
   const reverseEntryPointMap = invertObject(entryPointSourceMap)
 
   let entryPointOutputMap = {}
@@ -656,7 +655,7 @@ export async function main(argv) {
       '-p, --path-prefix <path>',
       'Prefix all import paths with the given path. Useful when serving behind a reverse proxy.',
     )
-    .option('--no-treeshake', 'Bundle all entry points into the import map.')
+    .option('--treeshake', 'Drop unused entry points from the import map.')
     .argument(
       '<package-dir>',
       'Path to package that will transformed. The directory must contain a valid package.json file.',

--- a/esimport.mjs
+++ b/esimport.mjs
@@ -226,11 +226,8 @@ export async function bundleExports(cwd, projectRoot) {
 class TreeShaker {
   #metafile
   #entryPointSourceMap
-  #projectRoot
-  #reachableKeys = new Set()
   #reachableOutputs = new Set()
-  #reverseEntryPointMap
-  #entryPointToOutput = {}
+  #entryPointToOutput
 
   /**
    * Walker over the metafile's reachability graph from the project's own entry points.
@@ -242,66 +239,48 @@ class TreeShaker {
   constructor(metafile, entryPointSourceMap, projectRoot) {
     this.#metafile = metafile
     this.#entryPointSourceMap = entryPointSourceMap
-    this.#projectRoot = projectRoot
-    this.#reverseEntryPointMap = invertObject(entryPointSourceMap)
-    for (const [name, output] of Object.entries(metafile.outputs)) {
-      if (output.entryPoint !== undefined) {
-        this.#entryPointToOutput[path.relative(projectRoot, output.entryPoint)] = name
-      }
-    }
+    this.#entryPointToOutput = Object.fromEntries(
+      Object.entries(metafile.outputs)
+        .filter(([, output]) => output.entryPoint !== undefined)
+        .map(([name, output]) => [path.relative(projectRoot, output.entryPoint), name]),
+    )
   }
 
   /**
-   * Yield the output and every output it reaches.
+   * Mark the output and every output it reaches as reachable.
    *
    * @param name {string|undefined} - The name of the output to walk.
-   * @yields {string} - The names of the reachable outputs.
    */
-  *#walk(name) {
+  #walk(name) {
     if (name === undefined || this.#reachableOutputs.has(name)) return
     this.#reachableOutputs.add(name)
-    yield name
-    const output = this.#metafile.outputs[name]
-
-    if (output.entryPoint !== undefined) {
-      for (const key of this.#reverseEntryPointMap[
-        path.relative(this.#projectRoot, output.entryPoint)
-      ]) {
-        this.#reachableKeys.add(key)
-      }
+    if (this.#metafile.outputs[`${name}.map`] !== undefined) {
+      this.#reachableOutputs.add(`${name}.map`)
     }
-
+    const output = this.#metafile.outputs[name]
     for (const { path: entryPoint } of output.imports) {
       const source = this.#entryPointSourceMap[entryPoint]
       if (source !== undefined && this.#entryPointToOutput[source] !== undefined) {
-        yield* this.#walk(this.#entryPointToOutput[source])
+        this.#walk(this.#entryPointToOutput[source])
       } else if (this.#metafile.outputs[entryPoint] !== undefined) {
-        yield* this.#walk(entryPoint)
+        this.#walk(entryPoint)
       }
     }
-
-    yield* this.#walk(output.cssBundle)
+    this.#walk(output.cssBundle)
   }
 
   /**
-   * Return the import-map keys and outputs reachable from the project's entry points.
+   * Walk every first-party entry point and return the reachable outputs.
    *
-   * @return {{reachableKeys: Set<string>, reachableOutputs: Set<string>}} - The reachable import-map keys and output file paths to keep.
+   * @return {Set<string>} - The output file paths to keep.
    */
   reachable() {
     for (const [source, name] of Object.entries(this.#entryPointToOutput)) {
       if (source.split(path.sep)[0] !== 'node_modules') {
-        for (const output of this.#walk(name)) {
-          if (this.#metafile.outputs[`${output}.map`] !== undefined) {
-            this.#reachableOutputs.add(`${output}.map`)
-          }
-        }
+        this.#walk(name)
       }
     }
-    return {
-      reachableKeys: this.#reachableKeys,
-      reachableOutputs: this.#reachableOutputs,
-    }
+    return this.#reachableOutputs
   }
 }
 
@@ -311,7 +290,7 @@ class TreeShaker {
  * @param metafile {esbuild.Metafile} - The esbuild build metafile.
  * @param entryPointSourceMap {Object.<string,string>} - A map of entry points to their file paths.
  * @param projectRoot {string} - The root directory of the project.
- * @return {{reachableKeys: Set<string>, reachableOutputs: Set<string>}} - The reachable import-map keys and output file paths to keep.
+ * @return {Set<string>} - The output file paths to keep.
  */
 export function treeShake(metafile, entryPointSourceMap, projectRoot) {
   return new TreeShaker(metafile, entryPointSourceMap, projectRoot).reachable()
@@ -346,7 +325,7 @@ async function build(projectRoot, outputDir, context, entryPointSourceMap, optio
       for (const e of reverseEntryPointMap[
         path.relative(projectRoot, output.entryPoint)
       ]) {
-        if (reachable === undefined || reachable.reachableKeys.has(e)) {
+        if (reachable === undefined || reachable.has(name)) {
           entryPointOutputMap[e] = `./${path.relative(outputDir, name)}`
         }
       }
@@ -355,7 +334,7 @@ async function build(projectRoot, outputDir, context, entryPointSourceMap, optio
 
   if (reachable !== undefined) {
     for (const name of Object.keys(result.metafile.outputs)) {
-      if (!reachable.reachableOutputs.has(name)) {
+      if (!reachable.has(name)) {
         await fs.rm(name, { force: true })
       }
     }

--- a/esimport.mjs
+++ b/esimport.mjs
@@ -221,6 +221,103 @@ export async function bundleExports(cwd, projectRoot) {
 }
 
 /**
+ * The reachability graph walker over the build metafile.
+ */
+class TreeShaker {
+  #metafile
+  #entryPointSourceMap
+  #projectRoot
+  #reachableKeys = new Set()
+  #reachableOutputs = new Set()
+  #reverseEntryPointMap
+  #entryPointToOutput = {}
+
+  /**
+   * Walker over the metafile's reachability graph from the project's own entry points.
+   *
+   * @param metafile {esbuild.Metafile} - The esbuild build metafile.
+   * @param entryPointSourceMap {Object.<string,string>} - A map of entry points to their file paths.
+   * @param projectRoot {string} - The root directory of the project.
+   */
+  constructor(metafile, entryPointSourceMap, projectRoot) {
+    this.#metafile = metafile
+    this.#entryPointSourceMap = entryPointSourceMap
+    this.#projectRoot = projectRoot
+    this.#reverseEntryPointMap = invertObject(entryPointSourceMap)
+    for (const [name, output] of Object.entries(metafile.outputs)) {
+      if (output.entryPoint !== undefined) {
+        this.#entryPointToOutput[path.relative(projectRoot, output.entryPoint)] = name
+      }
+    }
+  }
+
+  /**
+   * Yield the output and every output it reaches.
+   *
+   * @param name {string|undefined} - The name of the output to walk.
+   * @yields {string} - The names of the reachable outputs.
+   */
+  *#walk(name) {
+    if (name === undefined || this.#reachableOutputs.has(name)) return
+    this.#reachableOutputs.add(name)
+    yield name
+    const output = this.#metafile.outputs[name]
+
+    if (output.entryPoint !== undefined) {
+      for (const key of this.#reverseEntryPointMap[
+        path.relative(this.#projectRoot, output.entryPoint)
+      ]) {
+        this.#reachableKeys.add(key)
+      }
+    }
+
+    for (const { path: entryPoint } of output.imports) {
+      const source = this.#entryPointSourceMap[entryPoint]
+      if (source !== undefined && this.#entryPointToOutput[source] !== undefined) {
+        yield* this.#walk(this.#entryPointToOutput[source])
+      } else if (this.#metafile.outputs[entryPoint] !== undefined) {
+        yield* this.#walk(entryPoint)
+      }
+    }
+
+    yield* this.#walk(output.cssBundle)
+  }
+
+  /**
+   * Return the import-map keys and outputs reachable from the project's entry points.
+   *
+   * @return {{reachableKeys: Set<string>, reachableOutputs: Set<string>}} - The reachable import-map keys and output file paths to keep.
+   */
+  reachable() {
+    for (const [source, name] of Object.entries(this.#entryPointToOutput)) {
+      if (source.split(path.sep)[0] !== 'node_modules') {
+        for (const output of this.#walk(name)) {
+          if (this.#metafile.outputs[`${output}.map`] !== undefined) {
+            this.#reachableOutputs.add(`${output}.map`)
+          }
+        }
+      }
+    }
+    return {
+      reachableKeys: this.#reachableKeys,
+      reachableOutputs: this.#reachableOutputs,
+    }
+  }
+}
+
+/**
+ * Shake the project's import tree down to its reachable outputs.
+ *
+ * @param metafile {esbuild.Metafile} - The esbuild build metafile.
+ * @param entryPointSourceMap {Object.<string,string>} - A map of entry points to their file paths.
+ * @param projectRoot {string} - The root directory of the project.
+ * @return {{reachableKeys: Set<string>, reachableOutputs: Set<string>}} - The reachable import-map keys and output file paths to keep.
+ */
+export function treeShake(metafile, entryPointSourceMap, projectRoot) {
+  return new TreeShaker(metafile, entryPointSourceMap, projectRoot).reachable()
+}
+
+/**
  * Build the project using esbuild.
  *
  * @param projectRoot {string} - The root directory of the project.
@@ -237,6 +334,10 @@ async function build(projectRoot, outputDir, context, entryPointSourceMap, optio
   }
   console.info(`${Object.keys(result.metafile.inputs).length} ES modules processed.`)
 
+  const reachable =
+    options.treeshake === false
+      ? undefined
+      : treeShake(result.metafile, entryPointSourceMap, projectRoot)
   const reverseEntryPointMap = invertObject(entryPointSourceMap)
 
   let entryPointOutputMap = {}
@@ -245,7 +346,17 @@ async function build(projectRoot, outputDir, context, entryPointSourceMap, optio
       for (const e of reverseEntryPointMap[
         path.relative(projectRoot, output.entryPoint)
       ]) {
-        entryPointOutputMap[e] = `./${path.relative(outputDir, name)}`
+        if (reachable === undefined || reachable.reachableKeys.has(e)) {
+          entryPointOutputMap[e] = `./${path.relative(outputDir, name)}`
+        }
+      }
+    }
+  }
+
+  if (reachable !== undefined) {
+    for (const name of Object.keys(result.metafile.outputs)) {
+      if (!reachable.reachableOutputs.has(name)) {
+        await fs.rm(name, { force: true })
       }
     }
   }
@@ -568,6 +679,7 @@ export async function main(argv) {
       '-p, --path-prefix <path>',
       'Prefix all import paths with the given path. Useful when serving behind a reverse proxy.',
     )
+    .option('--no-treeshake', 'Bundle all entry points into the import map.')
     .argument(
       '<package-dir>',
       'Path to package that will transformed. The directory must contain a valid package.json file.',

--- a/tests/esimport.test.js
+++ b/tests/esimport.test.js
@@ -1,6 +1,7 @@
 import assert from 'node:assert/strict'
 import process from 'node:process'
 import path from 'node:path'
+import fs from 'node:fs/promises'
 import { describe, mock, test } from 'node:test'
 
 import * as esimport from 'esimport'
@@ -328,6 +329,137 @@ describe('invertObject', () => {
   })
 })
 
+describe('treeShake', () => {
+  const projectRoot = '/project'
+  const entryPointSourceMap = {
+    app: 'src/index.js',
+    dep: 'node_modules/dep/index.js',
+    'dep/sub': 'node_modules/dep/locale/index.js',
+  }
+
+  function makeMetafile() {
+    return {
+      outputs: {
+        '/project/out/app.js': {
+          entryPoint: path.join(projectRoot, 'src/index.js'),
+          imports: [
+            { path: 'dep/sub', kind: 'import-statement', external: false },
+            {
+              path: '/project/out/chunk.js',
+              kind: 'import-statement',
+              external: false,
+            },
+          ],
+          cssBundle: '/project/out/styles.css',
+          inputs: {},
+        },
+        '/project/out/app.js.map': {
+          entryPoint: undefined,
+          imports: [],
+          inputs: {},
+        },
+        '/project/out/dep.js': {
+          entryPoint: path.join(projectRoot, 'node_modules/dep/index.js'),
+          imports: [],
+          inputs: {},
+        },
+        '/project/out/dep.js.map': {
+          entryPoint: undefined,
+          imports: [],
+          inputs: {},
+        },
+        '/project/out/dep-locale.js': {
+          entryPoint: path.join(projectRoot, 'node_modules/dep/locale/index.js'),
+          imports: [],
+          inputs: {},
+        },
+        '/project/out/dep-locale.js.map': {
+          entryPoint: undefined,
+          imports: [],
+          inputs: {},
+        },
+        '/project/out/styles.css': {
+          entryPoint: undefined,
+          imports: [],
+          inputs: {},
+        },
+        '/project/out/styles.css.map': {
+          entryPoint: undefined,
+          imports: [],
+          inputs: {},
+        },
+        '/project/out/chunk.js': {
+          entryPoint: undefined,
+          imports: [],
+          inputs: {},
+        },
+        '/project/out/chunk.js.map': {
+          entryPoint: undefined,
+          imports: [],
+          inputs: {},
+        },
+      },
+    }
+  }
+
+  test('keeps 1st-party root entry point and its output', () => {
+    const { reachableKeys, reachableOutputs } = esimport.treeShake(
+      makeMetafile(),
+      entryPointSourceMap,
+      projectRoot,
+    )
+    assert(reachableKeys.has('app'))
+    assert(reachableOutputs.has('/project/out/app.js'))
+  })
+
+  test('keeps transitively imported dep subpath and drops unreferenced dep', () => {
+    const { reachableKeys, reachableOutputs } = esimport.treeShake(
+      makeMetafile(),
+      entryPointSourceMap,
+      projectRoot,
+    )
+    assert(reachableKeys.has('dep/sub'))
+    assert(reachableOutputs.has('/project/out/dep-locale.js'))
+    assert(!reachableKeys.has('dep'))
+    assert(!reachableOutputs.has('/project/out/dep.js'))
+  })
+
+  test('keeps cssBundle output for a reachable output', () => {
+    const { reachableOutputs } = esimport.treeShake(
+      makeMetafile(),
+      entryPointSourceMap,
+      projectRoot,
+    )
+    assert(reachableOutputs.has('/project/out/styles.css'))
+  })
+
+  test('keeps split-chunk outputs referenced via imports', () => {
+    const { reachableOutputs } = esimport.treeShake(
+      makeMetafile(),
+      entryPointSourceMap,
+      projectRoot,
+    )
+    assert(reachableOutputs.has('/project/out/chunk.js'))
+  })
+
+  test('keeps .map companion outputs for reachable outputs', () => {
+    const { reachableOutputs } = esimport.treeShake(
+      makeMetafile(),
+      entryPointSourceMap,
+      projectRoot,
+    )
+    for (const name of [
+      '/project/out/app.js.map',
+      '/project/out/dep-locale.js.map',
+      '/project/out/styles.css.map',
+      '/project/out/chunk.js.map',
+    ]) {
+      assert(reachableOutputs.has(name))
+    }
+    assert(!reachableOutputs.has('/project/out/dep.js.map'))
+  })
+})
+
 describe('compileEntryPoints', () => {
   test('compile entry points', async () => {
     assert.deepEqual(
@@ -405,6 +537,95 @@ describe('run', () => {
           'sha256-75BZz/UpPligxcmAdJnH+TJd/CIyRSjLA54xBpnRakQ= sha384-7mjoGvP3jSYReNFlnO6afThCYcCfvesfEDNcFTyAy3SAv5nJRCkYQ3ptT7kn43AK sha512-7dyswrItDz1PnA44eyfyzvWT1BqBf3AVXfBay914dNi3dJUSTOa0LE2zyGT/b+lNNNPLAS/+P87BL24pMsZZAA==',
       },
     })
+  })
+})
+
+describe('run (treeshake)', () => {
+  const fixtureDir = path.join(import.meta.dirname, 'fixtures/treeshake')
+  const outputDir = path.join(import.meta.dirname, 'fixtures/treeshake/out')
+
+  async function listFiles(dir) {
+    const files = []
+    for (const entry of await fs.readdir(dir, { recursive: true })) {
+      if ((await fs.stat(path.join(dir, entry))).isFile()) files.push(entry)
+    }
+    return files.sort()
+  }
+
+  test('treeshakes unreachable dependency entry points by default', async () => {
+    await fs.rm(outputDir, { recursive: true, force: true })
+    try {
+      const result = await esimport.run(fixtureDir, outputDir, {
+        watch: false,
+        verbose: false,
+      })
+      assert.deepEqual(Object.keys(result.imports).sort(), [
+        'date-utils/locale',
+        'treeshake-app',
+      ])
+      assert.deepEqual(
+        Object.keys(result.integrity).sort(),
+        Object.values(result.imports).sort(),
+      )
+      const files = await listFiles(outputDir)
+      assert(files.includes('importmap.json'))
+      assert(
+        files.some((f) => /^src\/index-.*\.js$/.test(f)),
+        'expected kept src/index-*.js',
+      )
+      assert(
+        files.some((f) => /^src\/index-.*\.js\.map$/.test(f)),
+        'expected kept src/index-*.js.map',
+      )
+      assert(
+        files.some((f) => /^node_modules\/date-utils\/locale\/index-.*\.js$/.test(f)),
+        'expected kept date-utils/locale output',
+      )
+      assert(
+        files.some((f) =>
+          /^node_modules\/date-utils\/locale\/index-.*\.js\.map$/.test(f),
+        ),
+        'expected kept date-utils/locale .map',
+      )
+      assert(
+        !files.some((f) => /^node_modules\/date-utils\/index-.*/.test(f)),
+        'unused date-utils output must be removed',
+      )
+      assert(
+        !files.some((f) => /^node_modules\/date-utils\/fp\/index-.*/.test(f)),
+        'unused date-utils/fp output must be removed',
+      )
+    } finally {
+      await fs.rm(outputDir, { recursive: true, force: true })
+    }
+  })
+
+  test('keeps all entry points when treeshake is disabled', async () => {
+    await fs.rm(outputDir, { recursive: true, force: true })
+    try {
+      const result = await esimport.run(fixtureDir, outputDir, {
+        watch: false,
+        verbose: false,
+        treeshake: false,
+      })
+      assert.deepEqual(Object.keys(result.imports).sort(), [
+        'date-utils',
+        'date-utils/fp',
+        'date-utils/locale',
+        'treeshake-app',
+      ])
+      const files = await listFiles(outputDir)
+      assert(
+        files.some((f) => /^node_modules\/date-utils\/index-.*\.js$/.test(f)),
+        'date-utils output should exist without treeshake',
+      )
+      assert(
+        files.some((f) => /^node_modules\/date-utils\/fp\/index-.*\.js$/.test(f)),
+        'date-utils/fp output should exist without treeshake',
+      )
+    } finally {
+      await fs.rm(outputDir, { recursive: true, force: true })
+    }
   })
 })
 

--- a/tests/esimport.test.js
+++ b/tests/esimport.test.js
@@ -402,48 +402,45 @@ describe('treeShake', () => {
     }
   }
 
-  test('keeps 1st-party root entry point and its output', () => {
-    const { reachableKeys, reachableOutputs } = esimport.treeShake(
+  test('keeps the 1st-party root entry point output', () => {
+    const reachable = esimport.treeShake(
       makeMetafile(),
       entryPointSourceMap,
       projectRoot,
     )
-    assert(reachableKeys.has('app'))
-    assert(reachableOutputs.has('/project/out/app.js'))
+    assert(reachable.has('/project/out/app.js'))
   })
 
-  test('keeps transitively imported dep subpath and drops unreferenced dep', () => {
-    const { reachableKeys, reachableOutputs } = esimport.treeShake(
+  test('keeps a transitively imported dep subpath and drops an unreferenced dep', () => {
+    const reachable = esimport.treeShake(
       makeMetafile(),
       entryPointSourceMap,
       projectRoot,
     )
-    assert(reachableKeys.has('dep/sub'))
-    assert(reachableOutputs.has('/project/out/dep-locale.js'))
-    assert(!reachableKeys.has('dep'))
-    assert(!reachableOutputs.has('/project/out/dep.js'))
+    assert(reachable.has('/project/out/dep-locale.js'))
+    assert(!reachable.has('/project/out/dep.js'))
   })
 
-  test('keeps cssBundle output for a reachable output', () => {
-    const { reachableOutputs } = esimport.treeShake(
+  test('keeps the cssBundle output for a reachable output', () => {
+    const reachable = esimport.treeShake(
       makeMetafile(),
       entryPointSourceMap,
       projectRoot,
     )
-    assert(reachableOutputs.has('/project/out/styles.css'))
+    assert(reachable.has('/project/out/styles.css'))
   })
 
   test('keeps split-chunk outputs referenced via imports', () => {
-    const { reachableOutputs } = esimport.treeShake(
+    const reachable = esimport.treeShake(
       makeMetafile(),
       entryPointSourceMap,
       projectRoot,
     )
-    assert(reachableOutputs.has('/project/out/chunk.js'))
+    assert(reachable.has('/project/out/chunk.js'))
   })
 
   test('keeps .map companion outputs for reachable outputs', () => {
-    const { reachableOutputs } = esimport.treeShake(
+    const reachable = esimport.treeShake(
       makeMetafile(),
       entryPointSourceMap,
       projectRoot,
@@ -454,9 +451,9 @@ describe('treeShake', () => {
       '/project/out/styles.css.map',
       '/project/out/chunk.js.map',
     ]) {
-      assert(reachableOutputs.has(name))
+      assert(reachable.has(name))
     }
-    assert(!reachableOutputs.has('/project/out/dep.js.map'))
+    assert(!reachable.has('/project/out/dep.js.map'))
   })
 })
 

--- a/tests/esimport.test.js
+++ b/tests/esimport.test.js
@@ -548,12 +548,13 @@ describe('run (treeshake)', () => {
     return files.sort()
   }
 
-  test('treeshakes unreachable dependency entry points by default', async () => {
+  test('treeshakes unreachable dependency entry points when enabled', async () => {
     await fs.rm(outputDir, { recursive: true, force: true })
     try {
       const result = await esimport.run(fixtureDir, outputDir, {
         watch: false,
         verbose: false,
+        treeshake: true,
       })
       assert.deepEqual(Object.keys(result.imports).sort(), [
         'date-utils/locale',
@@ -597,13 +598,12 @@ describe('run (treeshake)', () => {
     }
   })
 
-  test('keeps all entry points when treeshake is disabled', async () => {
+  test('keeps all entry points by default', async () => {
     await fs.rm(outputDir, { recursive: true, force: true })
     try {
       const result = await esimport.run(fixtureDir, outputDir, {
         watch: false,
         verbose: false,
-        treeshake: false,
       })
       assert.deepEqual(Object.keys(result.imports).sort(), [
         'date-utils',

--- a/tests/esimport.test.js
+++ b/tests/esimport.test.js
@@ -564,31 +564,32 @@ describe('run (treeshake)', () => {
         Object.values(result.imports).sort(),
       )
       const files = await listFiles(outputDir)
+      const outputFiles = files.join('\n')
       assert(files.includes('importmap.json'))
-      assert(
-        files.some((f) => /^src\/index-.*\.js$/.test(f)),
-        'expected kept src/index-*.js',
-      )
-      assert(
-        files.some((f) => /^src\/index-.*\.js\.map$/.test(f)),
+      assert.match(outputFiles, /^src\/index-.*\.js$/m, 'expected kept src/index-*.js')
+      assert.match(
+        outputFiles,
+        /^src\/index-.*\.js\.map$/m,
         'expected kept src/index-*.js.map',
       )
-      assert(
-        files.some((f) => /^node_modules\/date-utils\/locale\/index-.*\.js$/.test(f)),
+      assert.match(
+        outputFiles,
+        /^node_modules\/date-utils\/locale\/index-.*\.js$/m,
         'expected kept date-utils/locale output',
       )
-      assert(
-        files.some((f) =>
-          /^node_modules\/date-utils\/locale\/index-.*\.js\.map$/.test(f),
-        ),
+      assert.match(
+        outputFiles,
+        /^node_modules\/date-utils\/locale\/index-.*\.js\.map$/m,
         'expected kept date-utils/locale .map',
       )
-      assert(
-        !files.some((f) => /^node_modules\/date-utils\/index-.*/.test(f)),
+      assert.doesNotMatch(
+        outputFiles,
+        /^node_modules\/date-utils\/index-.*/m,
         'unused date-utils output must be removed',
       )
-      assert(
-        !files.some((f) => /^node_modules\/date-utils\/fp\/index-.*/.test(f)),
+      assert.doesNotMatch(
+        outputFiles,
+        /^node_modules\/date-utils\/fp\/index-.*/m,
         'unused date-utils/fp output must be removed',
       )
     } finally {
@@ -610,13 +611,15 @@ describe('run (treeshake)', () => {
         'date-utils/locale',
         'treeshake-app',
       ])
-      const files = await listFiles(outputDir)
-      assert(
-        files.some((f) => /^node_modules\/date-utils\/index-.*\.js$/.test(f)),
+      const outputFiles = (await listFiles(outputDir)).join('\n')
+      assert.match(
+        outputFiles,
+        /^node_modules\/date-utils\/index-.*\.js$/m,
         'date-utils output should exist without treeshake',
       )
-      assert(
-        files.some((f) => /^node_modules\/date-utils\/fp\/index-.*\.js$/.test(f)),
+      assert.match(
+        outputFiles,
+        /^node_modules\/date-utils\/fp\/index-.*\.js$/m,
         'date-utils/fp output should exist without treeshake',
       )
     } finally {

--- a/tests/fixtures/treeshake/.gitignore
+++ b/tests/fixtures/treeshake/.gitignore
@@ -1,0 +1,4 @@
+# Re-include the dependency fixture, which is otherwise excluded by the
+# top-level node_modules/ rule.
+!node_modules/
+!node_modules/**

--- a/tests/fixtures/treeshake/node_modules/date-utils/fp/index.js
+++ b/tests/fixtures/treeshake/node_modules/date-utils/fp/index.js
@@ -1,0 +1,3 @@
+export function fp() {
+  return 'unused';
+}

--- a/tests/fixtures/treeshake/node_modules/date-utils/index.js
+++ b/tests/fixtures/treeshake/node_modules/date-utils/index.js
@@ -1,0 +1,1 @@
+export function add() {}

--- a/tests/fixtures/treeshake/node_modules/date-utils/locale/en-US/index.js
+++ b/tests/fixtures/treeshake/node_modules/date-utils/locale/en-US/index.js
@@ -1,0 +1,1 @@
+export const locale = 'en-US'

--- a/tests/fixtures/treeshake/node_modules/date-utils/locale/index.js
+++ b/tests/fixtures/treeshake/node_modules/date-utils/locale/index.js
@@ -1,0 +1,5 @@
+import { locale } from './en-US/index.js'
+
+export function format() {
+  return locale;
+}

--- a/tests/fixtures/treeshake/node_modules/date-utils/package.json
+++ b/tests/fixtures/treeshake/node_modules/date-utils/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "date-utils",
+  "version": "1.0.0",
+  "exports": {
+    ".": "./index.js",
+    "./locale": "./locale/index.js",
+    "./fp": "./fp/index.js"
+  }
+}

--- a/tests/fixtures/treeshake/package.json
+++ b/tests/fixtures/treeshake/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "treeshake-app",
+  "version": "1.0.0",
+  "description": "Test fixture for import map treeshaking.",
+  "exports": {
+    ".": "./src/index.js"
+  },
+  "dependencies": {
+    "date-utils": "1.0.0"
+  }
+}

--- a/tests/fixtures/treeshake/src/index.js
+++ b/tests/fixtures/treeshake/src/index.js
@@ -1,0 +1,3 @@
+import { format } from 'date-utils/locale'
+
+export const message = format


### PR DESCRIPTION
## Why

Packages can define a lot of entry points, adding bloat to the import map. A clear example is `date-fns`, which exposes 740+ subpaths; importing only `date-fns/locale` still pulled every entry point into the map, inflating every rendered page.

## Approach

After esbuild bundles all entry points in a single pass, walk the build metafile's reachability graph starting from the project's own (1st-party) entry points and keep only reachable entry points in the import map. Unreachable generated files are removed from the output directory.

- `TreeShaker` class holds traversal state, walking via a private generator method (`#walk`) using `yield`/`yield*`.
- Kept outputs include reachable dependency subpaths (transitive), split-chunk outputs via `imports[].path`, CSS bundles via `cssBundle`, and each output's `.map` sourcemap.
- **Always on by default**; new `--no-treeshake` flag opts out.
- All 1st-party entry points kept unconditionally; only unreachable dependency entry points dropped.

This stacks on top of the tests-refactor PR (#112), which converts the test suite to strict assertions.