### PR TITLE
Replace prettier with biome pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -35,7 +35,6 @@ repos:
     rev: v0.6.1
     hooks:
       - id: biome-check
-        additional_dependencies: ["@biomejs/biome"]
   - repo: https://github.com/btford/write-good
     rev: v1.0.8
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -33,13 +33,11 @@ repos:
       - id: esupgrade
   - repo: local
     hooks:
-      - id: prettier
-        name: prettier
-        entry: prettier --check --write --ignore-unknown
-        args:
-          - --config=package.json
+      - id: biome
+        name: biome
+        entry: biome check --write --no-errors-on-unmatched
         language: node
-        additional_dependencies: ["prettier"]
+        additional_dependencies: ["@biomejs/biome"]
         types_or: [javascript]
   - repo: https://github.com/btford/write-good
     rev: v1.0.8

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -32,7 +32,7 @@ repos:
     hooks:
       - id: esupgrade
   - repo: https://github.com/biomejs/pre-commit
-    rev: v0.6.1
+    rev: v2.5.9
     hooks:
       - id: biome-check
   - repo: https://github.com/btford/write-good

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -31,14 +31,11 @@ repos:
     rev: 2025.22.2
     hooks:
       - id: esupgrade
-  - repo: local
+  - repo: https://github.com/biomejs/pre-commit
+    rev: v0.6.1
     hooks:
-      - id: biome
-        name: biome
-        entry: biome check --write --no-errors-on-unmatched
-        language: node
+      - id: biome-check
         additional_dependencies: ["@biomejs/biome"]
-        types_or: [javascript]
   - repo: https://github.com/btford/write-good
     rev: v1.0.8
     hooks:

--- a/biome.json
+++ b/biome.json
@@ -10,7 +10,7 @@
     "indentStyle": "space",
     "indentWidth": 2,
     "lineWidth": 88,
-    "useEditorconfig": false
+    "useEditorconfig": true
   },
   "javascript": {
     "formatter": {

--- a/biome.json
+++ b/biome.json
@@ -7,8 +7,6 @@
   },
   "formatter": {
     "enabled": true,
-    "indentStyle": "space",
-    "indentWidth": 2,
     "lineWidth": 88,
     "useEditorconfig": true
   },

--- a/biome.json
+++ b/biome.json
@@ -1,0 +1,21 @@
+{
+  "$schema": "https://biomejs.dev/schemas/latest/schema.json",
+  "vcs": {
+    "enabled": true,
+    "clientKind": "git",
+    "useIgnoreFile": true
+  },
+  "formatter": {
+    "enabled": true,
+    "indentStyle": "space",
+    "indentWidth": 2,
+    "lineWidth": 88,
+    "useEditorconfig": false
+  },
+  "javascript": {
+    "formatter": {
+      "quoteStyle": "single",
+      "semicolons": "asNeeded"
+    }
+  }
+}

--- a/esimport.mjs
+++ b/esimport.mjs
@@ -1,4 +1,11 @@
 #!/usr/bin/env node
+import crypto from 'node:crypto'
+import fs from 'node:fs/promises'
+import * as http from 'node:http'
+import path from 'node:path'
+import process from 'node:process'
+import url, { fileURLToPath } from 'node:url'
+import * as commander from 'commander'
 /**
  * Compile a project into static JavaScript modules and generate a browser importmap.
  *
@@ -6,18 +13,10 @@
  *     esimport <package-root> <output-dir>
  */
 import * as esbuild from 'esbuild'
-import process from 'node:process'
-import path from 'node:path'
-import url from 'node:url'
-import fs from 'node:fs/promises'
-import { fileURLToPath } from 'node:url'
 import { glob } from 'glob'
 import { minimatch } from 'minimatch'
-import * as commander from 'commander'
-import esimportPkgInfo from './package.json' with { type: 'json' }
-import crypto from 'node:crypto'
 import handler from 'serve-handler'
-import * as http from 'node:http'
+import esimportPkgInfo from './package.json' with { type: 'json' }
 
 /**
  * Yield integrity hashes for the given data using each of the specified algorithms.
@@ -78,7 +77,7 @@ export function resolveImport(entryPoint) {
     return resolveImport(entryPoint.filter((e) => typeof e === 'object')[0])
   }
   for (const key of ['browser', 'import', 'default']) {
-    if (entryPoint.hasOwnProperty(key) && entryPoint[key] !== undefined) {
+    if (Object.hasOwn(entryPoint, key) && entryPoint[key] !== undefined) {
       return resolveImport(entryPoint[key])
     }
   }
@@ -99,14 +98,14 @@ export function path2EntryPoint(filePath, pathPattern, entryPointPattern) {
   const pathPatternRexEx = new RegExp(
     path
       .normalize(pathPattern)
-      .replace(/[.+?^${}()|\[\]\\]/g, '\\$&')
-      .replace(/\*/, '\(\.\*\)'),
+      .replace(/[.+?^${}()|[\]\\]/g, '\\$&')
+      .replace(/\*/, '(.*)'),
   )
   if (!pathPatternRexEx.test(filePath)) {
     throw new Error(`Invalid path ${filePath} for entry point ${pathPatternRexEx}`)
   }
   return path.normalize(
-    filePath.replace(pathPatternRexEx, entryPointPattern.replace(/\*/, '\$1')),
+    filePath.replace(pathPatternRexEx, entryPointPattern.replace(/\*/, '$1')),
   )
 }
 
@@ -153,9 +152,9 @@ export function resolveEntryPoints(pkgName, entryPoints) {
   } else if (typeof entryPoints === 'object') {
     try {
       return { [pkgName]: resolveImport(entryPoints) }
-    } catch (e) {
+    } catch {
       return Object.entries(entryPoints)
-        .filter(([key, value]) => value !== undefined)
+        .filter(([, value]) => value !== undefined)
         .reduce((acc, [key, value]) => {
           acc[path.join(pkgName, key)] = resolveImport(value)
           return acc
@@ -534,12 +533,11 @@ export async function run(packageDir, outputDir, options) {
  * Parse string to integer and check if it's a valid port.
  *
  * @param value {string} -
- * @param dummyPrevious
  * @return {number}
  */
-export function parsePort(value, dummyPrevious) {
+export function parsePort(value) {
   const parsedValue = parseInt(value, 10)
-  if (isNaN(parsedValue)) {
+  if (Number.isNaN(parsedValue)) {
     throw new commander.InvalidArgumentError('Not a number.')
   } else if (!(49_151 >= parsedValue && parsedValue > 1024)) {
     throw new commander.InvalidArgumentError('Port must be between 1024 and 49151.')

--- a/package.json
+++ b/package.json
@@ -10,10 +10,6 @@
   "scripts": {
     "test": "node --test --experimental-test-coverage --test-coverage-exclude=tests/*"
   },
-  "prettier": {
-    "semi": false,
-    "singleQuote": true
-  },
   "repository": {
     "type": "git",
     "url": "git+https://github.com/codingjoe/esimport.git"

--- a/tests/esimport.test.js
+++ b/tests/esimport.test.js
@@ -1,10 +1,9 @@
 import assert from 'node:assert/strict'
-import process from 'node:process'
 import path from 'node:path'
+import process from 'node:process'
 import { describe, mock, test } from 'node:test'
 
 import * as esimport from 'esimport'
-import { run, UnenvResolvePlugin } from 'esimport'
 
 describe('integrityHashes', () => {
   test('default algorithms', () => {


### PR DESCRIPTION
## Why

Prettier only formats. Replacing it with Biome brings formatting and linting together in one tool and one pre-commit hook, so style and correctness issues are caught at the same time with a single, fast check.

## What changed

- Replace the local `prettier` pre-commit hook with `biome check --write`.
- Add `biome.json` mirroring the previous prettier/editorconfig style: single quotes, semicolons as needed, 2-space indent, 88 char line width.
- Drop the now-unused `prettier` block from `package.json`.
- Apply Biome's safe lint fixes so the hook passes: `Number.isNaN`, `Object.hasOwn`, unused `catch`/parameter cleanup, and import organization.

## Notes

The Biome hook is stricter than prettier because `biome check` also lints, not just formats. Future commits will be blocked on lint issues as well as formatting.